### PR TITLE
fix(empirical): stop start_services.sh hanging its caller through a pipe

### DIFF
--- a/extensions/empirical/utils/start_services.sh
+++ b/extensions/empirical/utils/start_services.sh
@@ -26,15 +26,36 @@ if [ -n "$WRDS_USER" ] && [ "$WRDS_USER" != "your-username" ] && [ -n "$WRDS_PAS
     else
         echo "Starting WRDS server (approve Duo when prompted)..."
         # wrds.Connection silently ignores the wrds_password kwarg — feed libpq via PGPASSWORD instead.
-        PGPASSWORD="$WRDS_PASS" PYTHONPATH=code python3 code/utils/wrds_server.py &
+        # Redirect the daemon's stdout/stderr to a log file (not the inherited fds) and disown it.
+        # Otherwise the backgrounded server holds this script's stdout open; when start_services.sh is
+        # invoked through a pipe (e.g. `... | tail`), the reader never sees EOF and the caller hangs
+        # indefinitely even though the script itself has finished.
+        mkdir -p process_log
+        # nohup/& here is deliberate: this is fixed infrastructure starting a persistent,
+        # host-shared daemon meant to outlive the calling session — not an agent-improvised
+        # job the harness should track (cf. templates/shared/bash_background.md).
+        PGPASSWORD="$WRDS_PASS" PYTHONPATH=code nohup python3 code/utils/wrds_server.py \
+            >> process_log/wrds_server.log 2>&1 &
+        # || true: if the daemon crashes before disown runs, no-job is not fatal under set -e;
+        # the readiness loop below reports the real failure.
+        disown 2>/dev/null || true
         # Wait for server to be ready
+        ready=0
         for i in $(seq 1 120); do
             sleep 1
             if PYTHONPATH=code python3 -c "from utils.wrds_client import wrds_ping; exit(0 if wrds_ping() else 1)" 2>/dev/null; then
                 echo "WRDS server ready"
+                ready=1
                 break
             fi
         done
+        # Fail loudly on timeout instead of falling through to "Services ready." with exit 0 —
+        # a silent false-success would let the pipeline start Stage 0 against a dead server.
+        if [ "$ready" -ne 1 ]; then
+            echo "ERROR: WRDS server did not become ready within 120s." >&2
+            echo "       Check process_log/wrds_server.log (Duo not approved? bad credentials? network?)." >&2
+            exit 1
+        fi
     fi
 else
     echo "WRDS: credentials not configured (set WRDS_USER and WRDS_PASS in .env), skipping"

--- a/templates/gitignore_project
+++ b/templates/gitignore_project
@@ -67,3 +67,7 @@ paper/*-SAVE-ERROR
 # rule still protects projects deployed on older code, and the brief window
 # during an update.sh refresh, from a stray tracked pid file.
 code/utils/.wrds_server.pid
+
+# Process log runtime output (e.g. wrds_server.log from start_services.sh);
+# committed process-log artifacts under process_log/ are added explicitly by scribe.
+process_log/*.log


### PR DESCRIPTION
## Problem

`start_services.sh` backgrounded the WRDS server with `&` but let it inherit the script's stdout/stderr. When the script runs through a pipe (as the harness always does, `... | tail`), the daemonized server held the pipe's write-end open, so the reader never saw EOF and the caller hung forever — even though the script had already finished. It looked like the command never answered, every time.

## Fix

- Redirect the daemon to `process_log/wrds_server.log` and `disown` it so it no longer holds the caller's pipe open. `disown 2>/dev/null || true` avoids a `set -e` abort if the daemon crashes before `disown` runs.
- Fail loudly (`exit 1` + stderr diagnostic) on the 120s readiness timeout instead of falling through to "Services ready." with exit 0, which would let the pipeline start Stage 0 against a dead server.
- gitignore `process_log/*.log` so the runtime log isn't `git status` noise; scribe still adds committed `process_log/` artifacts explicitly.

## Verification

- Returns in ~0.3–2.3s through a pipe (was: hung indefinitely)
- `wrds_ping()` → `True` after restart
- Timeout branch exits 1 with diagnostic; happy path still exits 0
- `bash -n` clean; two Sonnet audit rounds returned no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)